### PR TITLE
reduce garbageCreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-01-23
+
+### Fixed
+
+- reduced garbage creation
+
 ## [1.1.2] - 2024-03-04
 
 ### Fixed

--- a/Runtime/Scripts/TileHandler.cs
+++ b/Runtime/Scripts/TileHandler.cs
@@ -596,14 +596,21 @@ namespace Netherlands3D.CartesianTiles
                 int tilesizeIndex = tileSizes.IndexOf(layer.tileSize);
                 var neededTiles = tileDistances[tilesizeIndex];
 
-                var neededTileKeys = new HashSet<Vector2Int>(
-                    neededTiles.Select(neededTile => new Vector2Int(neededTile.x, neededTile.y))
-                );
 
                 // check for each active tile if the key is in the list of tilekeys within the viewrange
                 foreach (var kvp in layer.tiles)
                 {
-                    if (neededTileKeys.Contains(kvp.Key)) continue; 
+                    bool isneeded = false;
+                    for (int i = 0; i < neededTiles.Count; i++)
+                    {
+                        if (neededTiles[i].x == kvp.Key.x && neededTiles[i].y == kvp.Key.y)
+                        {
+                            isneeded = true;
+                            i = neededTiles.Count;
+                        }
+                    }
+                    if (isneeded) continue;
+
                     
                     // if the tile is not within the viewrange, set it up for removal
                     AddTileChange(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eu.netherlands3d.cartesiantiles",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "Netherlands3D - Cartesian Tiles",
   "description": "Loads and unloads datasets in a cartesian coordinateSystem",
   "unity": "2022.2",


### PR DESCRIPTION
in plaats van een hashset maken van de lijst met tegels, de lijst gewoon doorlopen en checken. de extra tijd die dit kost is niet merkbaar in de profiler, scheelt wel ruim 1.5kB aan garbage per frame